### PR TITLE
Fix initialization of eventbus testable nil map

### DIFF
--- a/eventbus.go
+++ b/eventbus.go
@@ -223,5 +223,8 @@ type testableEventBus struct {
 
 // NewTestableEventBus can be used for unit testing.
 func NewTestableEventBus() EventBus {
-	return &testableEventBus{}
+	return &testableEventBus{eventBus{
+		make(map[string][]*eventHandler),
+		sync.RWMutex{},
+	}}
 }


### PR DESCRIPTION
If the testable EventBus is used, the handler map is not initialized properly. 

Stack trace shows:
```
panic: assignment to entry in nil map [recovered]
	panic: assignment to entry in nil map

goroutine 456 [running]:
testing.tRunner.func1.2(0x19fa060, 0x1c0b4b0)
	/usr/local/go/src/testing/testing.go:1143 +0x332
testing.tRunner.func1(0xc000160600)
	/usr/local/go/src/testing/testing.go:1146 +0x4b6
panic(0x19fa060, 0x1c0b4b0)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
github.com/boot-go/boot.(*eventBus).Subscribe(0xc000146720, 0x19bd640, 0xc00096d240, 0x0, 0x0)
	/Users/leansch/go/pkg/mod/github.com/boot-go/boot@v1.0.0-rc/eventbus.go:93 +0x598
```
