### PR TITLE
Fix data races in eventbus.

### DIFF
--- a/eventbus.go
+++ b/eventbus.go
@@ -34,9 +34,10 @@ import (
 type eventBus struct {
 	Runtime   Runtime                   `boot:"wire"`
 	handlers  map[string][]*busListener // contains all handler for a given type
-	lock      sync.RWMutex              // a lock for the handler map
+	lock      sync.RWMutex              // a mutex for the handlers map and the isStarted flag
 	isStarted bool
-	queue     []any // the queue which will receive the events until the init phase is  changed
+	queue     []any        // the queue which will receive the events until the init phase is  changed
+	queueLock sync.RWMutex // a mutex for the queue of events
 }
 
 // Handler is a function which has one argument. This argument is usually a published event. An error
@@ -75,13 +76,20 @@ var (
 
 // Init is described in the Component interface
 func (bus *eventBus) Init() error {
+	bus.lock.Lock()
+	defer bus.lock.Unlock()
 	bus.isStarted = false
 	return nil
 }
 
 func (bus *eventBus) activate() error {
+	bus.lock.Lock()
 	bus.isStarted = true
+	bus.lock.Unlock()
+
 	// republishing queued events
+	bus.queueLock.RLock()
+	defer bus.queueLock.RUnlock()
 	Logger.Debug.Printf("eventbus started with %d queued events\n", len(bus.queue))
 	pubErr := newPublicError()
 	for _, event := range bus.queue {
@@ -276,8 +284,13 @@ func (bus *eventBus) Publish(event Event) (err error) {
 		return ErrEventMustNotBeNil
 	}
 	eventType = QualifiedName(event)
-	if !bus.isStarted {
+	bus.lock.RLock()
+	started := bus.isStarted
+	bus.lock.RUnlock()
+	if !started {
 		Logger.Debug.Printf("queuing event %s\n", eventType)
+		bus.queueLock.Lock()
+		defer bus.queueLock.Unlock()
 		bus.queue = append(bus.queue, event)
 		return
 	}

--- a/eventbus.go
+++ b/eventbus.go
@@ -292,7 +292,7 @@ func (bus *eventBus) Publish(event Event) (err error) {
 		bus.queueLock.Lock()
 		defer bus.queueLock.Unlock()
 		bus.queue = append(bus.queue, event)
-		return
+		return nil
 	}
 	Logger.Debug.Printf("publishing event %s\n", eventType)
 	if handlers, ok := bus.handlers[eventType]; ok && 0 < len(handlers) {

--- a/injection.go
+++ b/injection.go
@@ -103,7 +103,7 @@ func resolveDependency(regEntry *componentManager, reg *registry) (entries []*co
 	err = initComponent(regEntry)
 	if err != nil {
 		regEntry.state = Failed
-		return
+		return nil, err
 	}
 	regEntry.state = Initialized
 	entries = append(entries, regEntry)

--- a/session_test.go
+++ b/session_test.go
@@ -343,6 +343,19 @@ func (e *eventbusActivationTest) Init() error {
 	return e.Eventbus.Publish(testEvent{})
 }
 
+type eventbusActivationProcessTest struct {
+	Eventbus               EventBus `boot:"wire"`
+	initSubscribeReturnErr error
+}
+
+func (e *eventbusActivationProcessTest) Init() error { return nil }
+
+func (e *eventbusActivationProcessTest) Start() error {
+	return e.Eventbus.Publish(testEvent{})
+}
+
+func (e *eventbusActivationProcessTest) Stop() error { return nil }
+
 func TestSessionRunEventbusActivationFail(t *testing.T) {
 	type args struct {
 		create func() Component
@@ -357,6 +370,17 @@ func TestSessionRunEventbusActivationFail(t *testing.T) {
 			args: args{
 				create: func() Component {
 					return &eventbusActivationTest{
+						initSubscribeReturnErr: nil,
+					}
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "successful process component",
+			args: args{
+				create: func() Component {
+					return &eventbusActivationProcessTest{
 						initSubscribeReturnErr: nil,
 					}
 				},


### PR DESCRIPTION
When a boot component publishes an event during its Start method, the eventbus accesses some of its fields concurrently. Mutexes are used to lock these fields.

For reproduction execute the tests with `-race` flag including the new testcase `eventbusActivationProcessTest`.

___
Florian Paust <florian.paust@mercedes-benz.com> on behalf of Mercedes-Benz Tech Innovation GmbH,

## Mercedes-Benz Tech Innovation GmbH

Mercedes-Benz Tech Innovation GmbH (ehemals/formerly Daimler TSS GmbH)  
Wilhelm-Runge-Straße 11  
89081 Ulm, Germany  
Phone: +49 731 50506  
Fax: +49 731 5056599  
E-Mail: techinnovation@mercedes-benz.com

Sitz und Registergericht/Domicile and Register Court: Ulm, HRB-Nr./Commercial Register No.: 3844  
Geschäftsführung/Management: Daniel Geisel (Vorsitzender/Chairperson), Isabelle Krautwald

<https://www.mercedes-benz-techinnovation.com/en/imprint/>

___
Licensed under MIT.
